### PR TITLE
Add .NET Core Runtime 2.0.9 to CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,9 +21,10 @@ jobs:
       submodules: true
     presteps:
     - task: UseDotNet@2
-      displayName:  Use .NET Core SDK version 2.0.x
+      displayName:  Use .NET Core Runtime version 2.0.9
       inputs:
-        version:    2.0.x
+        packageType:  runtime
+        version:      2.0.9
     - task: UseDotNet@2
       displayName:  Use .NET Core SDK version 3.x
       inputs:

--- a/src/THNETII.Docgen.ViewComponents/THNETII.Docgen.ViewComponents.csproj
+++ b/src/THNETII.Docgen.ViewComponents/THNETII.Docgen.ViewComponents.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>


### PR DESCRIPTION
https://dev.azure.com/thnetii/docgen-net/_build/results?buildId=8429&view=results indicates this version is needed for running Razor pre-compilation successfully.